### PR TITLE
Call `octave` with `--no-history` flag

### DIFF
--- a/xfmavg/xfmavg
+++ b/xfmavg/xfmavg
@@ -248,7 +248,7 @@ if(!defined($nl_xfms[0])){
    
    # execute the octave script
    print STDOUT "Calling octave\n" if $opt{verbose};
-   $args = "octave < $tmpdir/script.m";
+   $args = "octave --no-history < $tmpdir/script.m";
    
    if($opt{'verbose'}){
       $args .= "\n";


### PR DESCRIPTION
`octave` should not write to the user's `~/.octave_hist` since `$HOME` may be read-only, e.g., when executing on a cluster.
